### PR TITLE
update license and README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,17 @@
                            CISCO SAMPLE CODE LICENSE
-                                  Version 1.0
-                Copyright (c) 2017 Cisco and/or its affiliates
+                                  Version 1.1
+                Copyright (c) 2019 Cisco and/or its affiliates
 
-   These terms govern this Cisco example or demo source code and its
-   associated documentation (together, the "Sample Code"). By downloading,
-   copying, modifying, compiling, or redistributing the Sample Code, you
-   accept and agree to be bound by the following terms and conditions (the
-   "License"). If you are accepting the License on behalf of an entity, you
-   represent that you have the authority to do so (either you or the entity,
-   "you"). Sample Code is not supported by Cisco TAC and is not tested for
-   quality or performance. This is your only license to the Sample Code and
-   all rights not expressly granted are reserved.
+   These terms govern this Cisco Systems, Inc. ("Cisco"), example or demo
+   source code and its associated documentation (together, the "Sample
+   Code"). By downloading, copying, modifying, compiling, or redistributing
+   the Sample Code, you accept and agree to be bound by the following terms
+   and conditions (the "License"). If you are accepting the License on
+   behalf of an entity, you represent that you have the authority to do so
+   (either you or the entity, "you"). Sample Code is not supported by Cisco
+   TAC and is not tested for quality or performance. This is your only
+   license to the Sample Code and all rights not expressly granted are
+   reserved.
 
    1. LICENSE GRANT: Subject to the terms and conditions of this License,
       Cisco hereby grants to you a perpetual, worldwide, non-exclusive, non-
@@ -27,7 +28,7 @@
       and services are licensed under their own separate terms and you shall
       not use the Sample Code in any way that violates or is inconsistent
       with those terms (for more information, please visit:
-      www.cisco.com/go/terms.
+      www.cisco.com/go/terms).
 
    3. OWNERSHIP: Cisco retains sole and exclusive ownership of the Sample
       Code, including all intellectual property rights therein, except with

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ansible-network-backup
+[![published](https://static.production.devnetcloud.com/codeexchange/assets/images/devnet-published.svg)](https://developer.cisco.com/codeexchange/github/repo/ciscops/ansible-network-backup)
+
+# Ansible Network Backup
 
 This role backs up the configuration of a network device into a git repository.
 
@@ -55,4 +57,4 @@ Adding as a submodule:
 ## License
 
 
-CISCO SAMPLE CODE LICENSE
+[CISCO SAMPLE CODE LICENSE](./LICENSE).


### PR DESCRIPTION
Using the CSCL version 1.0 is ok, but better to use the current/latest version. I also assumed the year should be 2019. If the code was written in 2017, please disregard that change.

In the README, I added the DevNet published badge. This should be good for promoting your repo and good for promoting Code Exchange. It is optional, so remove if you prefer to not have it.
I also added a link the license file.